### PR TITLE
Actually output coverage for an entire app at once

### DIFF
--- a/coverage-extractor/main.ts
+++ b/coverage-extractor/main.ts
@@ -1,5 +1,6 @@
+import fs from "fs";
 import { startClient } from "./protocol/socket";
-import type { newSource } from "@recordreplay/protocol";
+import type { getHitCountsResult, newSource } from "@recordreplay/protocol";
 import groupBy from "lodash/groupBy";
 import { createFileCoverage, createCoverageMap } from "istanbul-lib-coverage";
 import { createContext } from "istanbul-lib-report";
@@ -18,6 +19,14 @@ async function main() {
   processRecording(recordingId);
 }
 
+interface SourceGroups {
+  src: newSource[];
+  node_modules: newSource[];
+  other: newSource[];
+}
+
+const reIsJsSourceFile = /(js|ts)x?(\?[\w\d]+)*$/;
+
 function processRecording(recordingId: string) {
   startClient(async client => {
     const { sessionId } = await client.Recording.createSession({ recordingId });
@@ -27,74 +36,130 @@ function processRecording(recordingId: string) {
     client.Debugger.addNewSourceListener(source => sources.push(source));
     await client.Debugger.findSources({}, sessionId);
 
-    const demoSourceEntry = sources.find(s => s.url?.endsWith("demo-script.js"))!;
+    const sourceGroups: SourceGroups = {
+      src: [],
+      node_modules: [],
+      other: [],
+    };
 
-    const demoSourceText = await client.Debugger.getSourceContents(
-      {
-        sourceId: demoSourceEntry.sourceId,
-      },
-      sessionId
-    );
+    sources.forEach(entry => {
+      if (!entry.url || !reIsJsSourceFile.test(entry.url)) {
+        sourceGroups.other.push(entry);
+        return;
+      }
 
-    // console.log("Demo source: ", demoSourceText.contents);
-    const { lineLocations } = await client.Debugger.getPossibleBreakpoints(
-      {
-        sourceId: demoSourceEntry.sourceId,
-      },
-      sessionId
-    );
-
-    const hitCounts = await client.Debugger.getHitCounts(
-      {
-        sourceId: demoSourceEntry.sourceId,
-        locations: lineLocations,
-        maxHits: 250,
-      },
-      sessionId
-    );
-
-    const hitsByLine = groupBy(hitCounts.hits, entry => entry.location.line);
-    const demoFileCoverage = createFileCoverage(demoSourceEntry.url!);
-
-    const allStatementHits = Object.entries(hitsByLine).flatMap(([key, locations]) => {
-      const statementHits = locations.map((l, index) => {
-        const endColumn = locations[index + 1]?.location.column ?? 255;
-        return {
-          start: l.location.column,
-          end: endColumn,
-          hits: l.hits,
-          line: l.location.line,
-        };
-      });
-      return statementHits;
+      const url = new URL(entry.url);
+      // TODO This check for "real sources" is fairly specific to Replay's source and build tooling atm
+      if (
+        url.pathname.startsWith("/src") &&
+        url.protocol == "webpack:" &&
+        entry.kind === "sourceMapped"
+      ) {
+        sourceGroups.src.push(entry);
+      } else if (url.pathname.startsWith("/node_modules")) {
+        sourceGroups.node_modules.push(entry);
+      } else {
+        sourceGroups.other.push(entry);
+      }
     });
 
-    allStatementHits.forEach((statement, index) => {
-      demoFileCoverage.statementMap[index] = {
-        start: {
-          line: statement.line,
-          column: statement.start,
-        },
-        end: {
-          line: statement.line,
-          column: statement.end,
-        },
-      };
-
-      demoFileCoverage.s[index] = statement.hits;
-    });
+    if (sourceGroups.src.length === 0) {
+      console.log("No matching sources found, exiting");
+      process.exit(0);
+    }
 
     const coverageMap = createCoverageMap();
-    coverageMap.addFileCoverage(demoFileCoverage);
+
+    const fileSourceContentsMap: Record<string, string> = {};
+
+    for (let sourceEntry of sourceGroups.src) {
+      console.log("Fetching source data: ", sourceEntry.url);
+      const demoSourceText = await client.Debugger.getSourceContents(
+        {
+          sourceId: sourceEntry.sourceId,
+        },
+        sessionId
+      );
+
+      const fileUrl = new URL(sourceEntry.url!);
+      const filePath = fileUrl.pathname;
+
+      fileSourceContentsMap[filePath] = demoSourceText.contents;
+
+      const { lineLocations } = await client.Debugger.getPossibleBreakpoints(
+        {
+          sourceId: sourceEntry.sourceId,
+        },
+        sessionId
+      );
+
+      let hitCounts: getHitCountsResult = {
+        hits: [],
+      };
+
+      try {
+        hitCounts = await client.Debugger.getHitCounts(
+          {
+            sourceId: sourceEntry.sourceId,
+            locations: lineLocations,
+            maxHits: 250,
+          },
+          sessionId
+        );
+      } catch (err: any) {
+        console.error("Error fetching ", sourceEntry.url, err.message);
+      }
+
+      const hitsByLine = groupBy(hitCounts.hits, entry => entry.location.line);
+
+      const fileCoverage = createFileCoverage(filePath);
+
+      const allStatementHits = Object.entries(hitsByLine).flatMap(([key, locations]) => {
+        const statementHits = locations.map((l, index) => {
+          const endColumn = locations[index + 1]?.location.column ?? 255;
+          return {
+            start: l.location.column,
+            end: endColumn,
+            hits: l.hits,
+            line: l.location.line,
+          };
+        });
+        return statementHits;
+      });
+
+      allStatementHits.forEach((statement, index) => {
+        fileCoverage.statementMap[index] = {
+          start: {
+            line: statement.line,
+            column: statement.start,
+          },
+          end: {
+            line: statement.line,
+            column: statement.end,
+          },
+        };
+
+        fileCoverage.s[index] = statement.hits;
+      });
+
+      coverageMap.addFileCoverage(fileCoverage);
+    }
+
+    const outputCoveragePath = `./coverage/${recordingId}`;
+
+    if (fs.existsSync(outputCoveragePath)) {
+      fs.rmSync(outputCoveragePath, { recursive: true, force: true });
+    }
 
     const context = createContext({
-      dir: "./coverage",
+      dir: outputCoveragePath,
       coverageMap,
       sourceFinder: filePath => {
-        if (filePath === demoSourceEntry.url!) {
-          return demoSourceText.contents;
+        if (filePath in fileSourceContentsMap) {
+          return fileSourceContentsMap[filePath];
         }
-        throw new Error(`Could not find file for source path: ${filePath}`);
+        console.error(`Could not find file for source path: ${filePath}`);
+        return "";
       },
     });
 


### PR DESCRIPTION
This PR:

- Updates the `coverage-extractor` example to loop over all source files, identify which ones _appear_ to be "real sources", and output coverage for all of them

Note that the criteria being used right now is fairly specific to Replay's own codebase, and in fact probably doesn't even work on the demo app recording any more.  I'm checking for a URL prefix of `webpack:`, and a source entry type of `"sourceMapped"`.

This actually does work!  Here's coverage for the actual Replay codebase from a recording at https://app.replay.io/recording/elements-and-box-model-interactions--4c229b2e-c054-4004-825d-e200b14b8a71 :

![image](https://user-images.githubusercontent.com/1128784/176006542-125cf954-822c-4e67-9a66-5c64a90c2473.png)
