### PR TITLE
Fix sources logic in coverage-extractor example

### DIFF
--- a/coverage-extractor/main.ts
+++ b/coverage-extractor/main.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { startClient } from "./protocol/socket";
-import type { getHitCountsResult, newSource } from "@recordreplay/protocol";
+import type { getHitCountsResult, newSource } from "@replayio/protocol";
 import groupBy from "lodash/groupBy";
 import { createFileCoverage, createCoverageMap } from "istanbul-lib-coverage";
 import { createContext } from "istanbul-lib-report";
@@ -33,7 +33,7 @@ function processRecording(recordingId: string) {
 
     const sources: newSource[] = [];
     // Fetch the sources
-    client.Debugger.addNewSourceListener(source => sources.push(source));
+    client.Debugger.addNewSourcesListener(newSources => sources.push(...newSources.sources));
     await client.Debugger.findSources({}, sessionId);
 
     const sourceGroups: SourceGroups = {
@@ -48,6 +48,7 @@ function processRecording(recordingId: string) {
         return;
       }
 
+      console.log("URL path: ", entry.url);
       const url = new URL(entry.url);
       // TODO This check for "real sources" is fairly specific to Replay's source and build tooling atm
       if (
@@ -56,8 +57,6 @@ function processRecording(recordingId: string) {
         entry.kind === "sourceMapped"
       ) {
         sourceGroups.src.push(entry);
-      } else if (url.pathname.startsWith("/node_modules")) {
-        sourceGroups.node_modules.push(entry);
       } else {
         sourceGroups.other.push(entry);
       }

--- a/coverage-extractor/package.json
+++ b/coverage-extractor/package.json
@@ -18,7 +18,7 @@
     "prettier": "^2.6.1"
   },
   "dependencies": {
-    "@recordreplay/protocol": "^0.21.0",
+    "@replayio/protocol": "^0.59.0",
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.4",

--- a/coverage-extractor/protocol/socket.ts
+++ b/coverage-extractor/protocol/socket.ts
@@ -8,7 +8,7 @@ import {
   PauseId,
   CommandParams,
   CommandResult,
-} from "@recordreplay/protocol";
+} from "@replayio/protocol";
 import { defer } from "./utils";
 
 const address = "wss://dispatch.replay.io";

--- a/coverage-extractor/yarn.lock
+++ b/coverage-extractor/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@recordreplay/protocol@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@recordreplay/protocol/-/protocol-0.21.0.tgz#5447a3b8d3cc14106ea6b3cb0cb4957c0e92300e"
-  integrity sha512-vrs+27UpTyH+o9FhhOu8cARz9RWzb2nkUPp9I9aDAXRX5DcDliSSCPX7vo1v1pdR7vSKK0Md+gnhKS3rK0IXCA==
+"@replayio/protocol@^0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@replayio/protocol/-/protocol-0.61.0.tgz#655985c421677d95fd690957680e0d4227349730"
+  integrity sha512-AhpgQ/S4ZvBsEiXgzTeS6JbgdYNCx/EzIvcRvvqBmMcY3qN3cdYnhXRevtN6scR/pKKyD7q/nQod9nKOb7upmQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.4":
   version "2.0.4"

--- a/react-mount-detection/main.ts
+++ b/react-mount-detection/main.ts
@@ -45,6 +45,8 @@ function getSourceLocationPoints(
   sessionId: string,
   location: Location
 ): Promise<PointDescription[]> {
+  // TODO The Analysis API was removed from our protocol a while back.
+  // Today you'd use `Session.findPoints` and `Session.runEvaluation`.
   return new Promise(async resolve => {
     const { analysisId } = await client.Analysis.createAnalysis(
       {


### PR DESCRIPTION
This PR:

- Updates the Replay protocol package version in the `coverage-extractor` example
- Fixes the sources fetching logic to make use of the revised sources event
- Adds a comment to the `react-mount-detection` example that it's outdated